### PR TITLE
Add NAMESERVER and SEARCHDOMAIN parameters from /etc/vz/vz.conf

### DIFF
--- a/virtuozzo_7_users_guide.asc
+++ b/virtuozzo_7_users_guide.asc
@@ -3956,6 +3956,7 @@ To set a DNS search domain for the virtual machine `MyVM` and the container `MyC
 . Network adapters operating in the routed mode must have at least one static IP address assigned.
 . To assign network masks to containers operating in the `venet0` networking mode, you must set the `USE_VENET_MASK` parameter in the `/etc/vz/vz.conf` configuration file to `yes`.
 . Containers can have only one network adapter operating in the host-routed mode. This adapter is automatically created when you create a virtual machine.
+. You can set nameservers and searchdomain in `/etc/vz/vz.conf` with `NAMESERVER` and `SEARCHDOMAIN` parameters. If you set it to `inherit`  - it copy values from host system's /etc/resolv.conf.
 ====
 
 Switching Virtual Machine Adapters to Host-Routed Mode


### PR DESCRIPTION
Add vz.conf parameters NAMESERVER and SEARCHDOMAIN with inherit value.
Based on https://bugs.openvz.org/browse/OVZ-6933